### PR TITLE
added ofxBulletStaticPlane for creating floors, ceilings etc.

### DIFF
--- a/src/shapes/ofxBulletBaseShape.cpp
+++ b/src/shapes/ofxBulletBaseShape.cpp
@@ -60,14 +60,18 @@ void ofxBulletBaseShape::remove() {
         }
     }
     
+    removeShape();
+	removeRigidBody();
+}
+
+//--------------------------------------------------------------
+void ofxBulletBaseShape::removeShape() {
     if(_bColShapeCreatedInternally) {
         if(_shape) {
             delete _shape;
             _shape = NULL;
         }
     }
-    
-	removeRigidBody();
 }
 
 //--------------------------------------------------------------

--- a/src/shapes/ofxBulletBaseShape.h
+++ b/src/shapes/ofxBulletBaseShape.h
@@ -32,8 +32,9 @@ public:
 	
 	virtual void create( btDiscreteDynamicsWorld* a_world, btCollisionShape* a_colShape, btTransform a_bt_tr, float a_mass );
 	virtual void add();
-	void	remove();
-	void	removeRigidBody();
+    virtual void remove();
+    virtual void removeShape();
+	virtual void removeRigidBody();
 	
 	// GETTERS //
 	btRigidBody*	getRigidBody();

--- a/src/shapes/ofxBulletStaticPlane.cpp
+++ b/src/shapes/ofxBulletStaticPlane.cpp
@@ -1,0 +1,57 @@
+//
+//  ofxBulletStaticPlane.cpp
+//  emptyExample
+//
+//  Created by Lukasz Karluk on 18/12/12.
+//
+//
+
+#include "ofxBulletStaticPlane.h"
+#include "btBulletDynamicsCommon.h"
+
+ofxBulletStaticPlane::ofxBulletStaticPlane() {
+    //
+}
+
+ofxBulletStaticPlane::~ofxBulletStaticPlane() {
+    //
+}
+
+void ofxBulletStaticPlane::init(btStaticPlaneShape * shape) {
+    _shape = shape;
+    _bColShapeCreatedInternally = false;
+    _bInited = true;
+}
+
+void ofxBulletStaticPlane::createFloor(btDiscreteDynamicsWorld * world, ofPoint planePosition) {
+    create(world, planePosition, ofPoint(0, -1, 0));
+}
+
+void ofxBulletStaticPlane::createCeiling(btDiscreteDynamicsWorld * world, ofPoint planePosition) {
+    create(world, planePosition, ofPoint(0, 1, 0));
+}
+
+void ofxBulletStaticPlane::create(btDiscreteDynamicsWorld * world, ofPoint planePosition, ofPoint planeNormal, float planeConstant) {
+    btStaticPlaneShape * staticPlaneShape = NULL;
+    if(_bInited == false || _shape == NULL) {
+        staticPlaneShape = new btStaticPlaneShape(btVector3(planeNormal.x, planeNormal.y, planeNormal.z), planeConstant);
+        _bInited = true;
+    } else {
+        staticPlaneShape = (btStaticPlaneShape *)_shape;
+    }
+    
+    btTransform transform = ofGetBtTransformFromVec3f(planePosition);
+    float mass = 0.0;
+    ofxBulletBaseShape::create(world, staticPlaneShape, transform, mass);
+    
+    createInternalUserData();
+}
+
+void ofxBulletStaticPlane::removeShape() {
+    if(_bColShapeCreatedInternally) {
+        if(_shape) {
+            delete (btStaticPlaneShape *)_shape;
+            _shape = NULL;
+        }
+    }
+}

--- a/src/shapes/ofxBulletStaticPlane.h
+++ b/src/shapes/ofxBulletStaticPlane.h
@@ -1,0 +1,27 @@
+//
+//  ofxBulletStaticPlane.h
+//  emptyExample
+//
+//  Created by Lukasz Karluk on 18/12/12.
+//
+//
+
+#pragma once
+
+#include "ofxBulletBaseShape.h"
+
+class ofxBulletStaticPlane : public ofxBulletBaseShape {
+    
+public:
+    
+    ofxBulletStaticPlane();
+    ~ofxBulletStaticPlane();
+    
+    void init(btStaticPlaneShape * shape);
+    
+    void createFloor(btDiscreteDynamicsWorld * world, ofPoint planePosition);
+    void createCeiling(btDiscreteDynamicsWorld * world, ofPoint planePosition);
+    void create(btDiscreteDynamicsWorld * world, ofPoint planePosition, ofPoint planeNormal, float planeConstant=1);
+    
+    void removeShape();
+};


### PR DESCRIPTION
hi Nick,
you've done a great job on this addon.
ive forked your repo and have been adding some stuff that i've used in the past on my own bullet projects.
i want to keep my fork as close to yours as possible and will be sending a lot of my PR updates.
hopefully we can work on this together.

this PR is adding ofxBulletStaticPlane,
which is used for creating floor or ceiling planes which are infinite.

one thing i needed to do is create a `removeShape()` method in ofxBulletBaseShape to isolate the shape destruction code so it can be overridden by ofxBulletStaticPlane. this is because the `_shape` needs to be cast back to `(btStaticPlaneShape *)_shape` when deleting otherwise it will cause leaks.

let me know what you think.

L.
