### PR TITLE
Update ofxBulletJoint.cpp

### DIFF
--- a/src/joints/ofxBulletJoint.cpp
+++ b/src/joints/ofxBulletJoint.cpp
@@ -29,7 +29,8 @@ void ofxBulletJoint::create( btDiscreteDynamicsWorld* a_world, ofxBulletRigidBod
 	a_shape2->setActivationState( DISABLE_DEACTIVATION );
 	
 	ofVec3f diff = a_shape2->getPosition() - a_shape1->getPosition();
-	
+	diff = diff * a_shape1->getRotationQuat().inverse();
+
 	btTransform frameInA = btTransform::getIdentity();
 	frameInA.setOrigin( btVector3(btScalar(-diff.x), btScalar(-diff.y), btScalar(-diff.z)) );
 	btTransform frameInB = btTransform::getIdentity();


### PR DESCRIPTION
not sure if there's a better way to do this -- but this change allows for the 1st rigid body to be rotated and the joint to be facing the right way 

I have an example project where I created 20 rigid body cylinders in a circle that have been rotated so the flat part of the cylinders face the next cylinder, if I create joints between them and run the simulation they all rotate back so the flat parts are facing (0,1,0). This update fixes that and it doesn't seem to break instances where the joint isn't rotated